### PR TITLE
Fix/flickering

### DIFF
--- a/src/components/CardList/CardList.js
+++ b/src/components/CardList/CardList.js
@@ -11,7 +11,7 @@ const CardList = props => {
   /* prettier-ignore */
   const Item = useCallback(({ data }) => {
     return <Card cardData={data} onCardLinkClick={onCardLinkClick} hasMainShow={hasMainShow} />;
-  }, [onCardLinkClick]);
+	}, [onCardLinkClick, hasMainShow]);
 
   return (
     <CardListStyled>

--- a/src/components/InfiniteScroller/InfiniteScroller.js
+++ b/src/components/InfiniteScroller/InfiniteScroller.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, memo, useEffect, useMemo } from "react";
+import React, { useCallback, useRef, memo, useState, useEffect } from "react";
 import { FixedSizeList } from "react-window";
 import InfiniteLoader from "react-window-infinite-loader";
 import AutoSizer from "react-virtualized-auto-sizer";
@@ -12,13 +12,14 @@ const InfiniteScroller = props => {
   const loadMoreItems = useCallback(isNextPageLoading ? () => {} : loadNextPage, [isNextPageLoading, loadNextPage]);
   const fixedSizeListRef = useRef();
   const MemoizedItem = memo(({ data }) => <Item data={data} />);
+  const [isMount, setIsMount] = useState(false);
 
   const handleWindowScroll = useCallback(({ scrollTop }) => {
     fixedSizeListRef.current.scrollTo(scrollTop);
   }, []);
 
   const Row = ({ index, style }) => {
-    if (!isItemLoaded(index)) {
+    if (!isMount || !isItemLoaded(index)) {
       return (
         <div style={style}>
           <LoadingIndicator />
@@ -33,21 +34,25 @@ const InfiniteScroller = props => {
     );
   };
 
+  useEffect(() => {
+    setTimeout(() => setIsMount(true), 100);
+  }, []);
+
   return (
     <>
       <WindowScroller onScroll={handleWindowScroll}>{() => <div />}</WindowScroller>
       <InfiniteLoader itemCount={itemCount} loadMoreItems={loadMoreItems} isItemLoaded={isItemLoaded}>
         {({ onItemsRendered, ref }) => {
           return (
-            <AutoSizer>
-              {({ width, height }) => (
+            <AutoSizer disableHeight>
+              {({ width }) => (
                 <FixedSizeList
                   ref={listRef => {
                     ref(listRef);
                     fixedSizeListRef.current = listRef;
                   }}
                   width={width}
-                  height={height}
+                  height={window.innerHeight}
                   itemCount={itemCount}
                   itemSize={itemSize}
                   onItemsRendered={onItemsRendered}

--- a/src/components/InfiniteScroller/InfiniteScroller.js
+++ b/src/components/InfiniteScroller/InfiniteScroller.js
@@ -35,7 +35,7 @@ const InfiniteScroller = props => {
   };
 
   useEffect(() => {
-    setTimeout(() => setIsMount(true), 100);
+    setTimeout(() => setIsMount(true), 300);
   }, []);
 
   return (


### PR DESCRIPTION
상세 페이지 진입 후 메인 페이지 재진입시 ios 사파리에서 확인해봤을때 아주 잠깐 깜빡이는 현상이 매우 거슬려서 제거하려고 했는데 엄청난 삽질끝에 임시본으로 작업했습니다.

- 아주 짧은 시간 100ms ~ 300ms동안 placeholder를 보여주는 방식으로 타협했습니다.
- 혹시 더 좋은 방법 있으면 제안 부탁드립니다.
useEffect(() => {
    setTimeout(() => setIsMount(true), 300);
  }, []);

이부분을 제거하면 깜빡임 현상 확인 가능합니다.
