### PR TITLE
fetchCard의 pageNumber가 1일 때 중복된 데이터를 또 불러오는 문제 수정

### DIFF
--- a/src/stores/CardStore.js
+++ b/src/stores/CardStore.js
@@ -27,7 +27,11 @@ class CardStore {
     const coordinates = yield GeoLocationUtils.getGeoLocation();
     const cards = yield CardRepository.getCards(pageNumber || this.pageNumber, coordinates.latitude, coordinates.longitude);
     const cardModels = cards.map(card => new CardModel(card));
-    set(this, { cardDatas: this.cardDatas.concat(cardModels) });
+    if (pageNumber === 1) {
+      set(this, { cardDatas: cardModels });
+    } else {
+      set(this, { cardDatas: this.cardDatas.concat(cardModels) });
+    }
     this.pageNumber++;
     this.cardDataCount = this.cardDatas.length;
     this.isLoading.fetchCard = false;


### PR DESCRIPTION
브랜치 이름이 `fix/map-marker`인 이유는 똑같은 위치에 마커가 중복되서 뜨길래 마커 문제인 줄 알고 수정을 시작했기 때문입니다...

`fetchCard`에서 `pageNumber`가 1일 때 `concat` 사용되지 않도록 수정해두었습니다.