### PR TITLE
지도 페이지에서 카드 데이터 로딩 시 현위치 아이콘이 반짝이도록 구현

### DIFF
--- a/src/components/BlinkingLocationIcon/BlinkingLocationIcon.js
+++ b/src/components/BlinkingLocationIcon/BlinkingLocationIcon.js
@@ -1,0 +1,22 @@
+import React, { useState, useEffect } from "react";
+import { ReactComponent as LocationIcon } from "../../images/icon-locate.svg";
+import { ReactComponent as LocationActiveIcon } from "../../images/icon-locate-active.svg";
+
+const BlinkingLocationIcon = () => {
+  const [isActiveIcon, setIsActiveIcon] = useState(false);
+  useEffect(() => {
+    const blinkInterval = setInterval(() => {
+      setIsActiveIcon(prevState => {
+        return !prevState;
+      });
+    }, 500);
+
+    return function cleanup() {
+      clearInterval(blinkInterval);
+    };
+  });
+
+  return isActiveIcon ? <LocationActiveIcon /> : <LocationIcon />;
+};
+
+export default BlinkingLocationIcon;

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-nested-ternary */
 import React, { useCallback, useRef } from "react";
 import HeaderStyled from "./Header.styles";
 import { ReactComponent as BackIcon } from "../../images/icon-back.svg";
@@ -5,9 +6,10 @@ import { ReactComponent as MapIcon } from "../../images/icon-map.svg";
 import { ReactComponent as LocationIcon } from "../../images/icon-locate.svg";
 import { ReactComponent as LocationActiveIcon } from "../../images/icon-locate-active.svg";
 import { ReactComponent as ShareIcon } from "../../images/icon-share.svg";
+import BlinkingLocationIcon from "../BlinkingLocationIcon/BlinkingLocationIcon";
 
 const Header = props => {
-  const { title, hasBackButton, hasShareButton, hasMapButton, hasLocalText, hasLocationButton, currentCoordinates, isFetching } = props;
+  const { title, hasBackButton, hasShareButton, hasMapButton, hasLocalText, hasLocationButton, currentCoordinates, isFetching, isLoadingFetchCard, isCardDatasEmpty } = props;
   const headerRef = useRef();
 
   const handleLocationButtonClick = useCallback(() => {
@@ -40,7 +42,7 @@ const Header = props => {
         <div className="right-box">
           {hasLocationButton && (
             <button className="navi-btn" onClick={handleLocationButtonClick}>
-              {!currentCoordinates || isFetching ? <LocationIcon /> : <LocationActiveIcon />}
+              {!currentCoordinates || isFetching ? <LocationIcon /> : isCardDatasEmpty && isLoadingFetchCard ? <BlinkingLocationIcon /> : <LocationActiveIcon />}
             </button>
           )}
           {hasShareButton && (
@@ -71,6 +73,8 @@ Header.defaultProps = {
   hasLocationButton: true,
   hasLocationActiveButton: false,
   isFetching: false,
+  isLoadingFetchCard: false,
+  isCardDatasEmpty: false,
 };
 
 export default Header;

--- a/src/containers/HeaderContainer.js
+++ b/src/containers/HeaderContainer.js
@@ -1,6 +1,7 @@
 import React, { useCallback } from "react";
 import { useHistory } from "react-router-dom";
 import { observer } from "mobx-react";
+import { isEmpty } from "lodash";
 import useStore from "../hooks/useStore";
 import Header from "../components/Header/Header";
 import useGeoLocation from "../hooks/useGeoLocation";
@@ -59,6 +60,8 @@ const HeaderContainer = props => {
         hasLocationButton={hasLocationButton}
         currentCoordinates={currentCoordinates}
         isFetching={isFetching}
+        isLoadingFetchCard={CardStore.isLoading.fetchCard}
+        isCardDatasEmpty={isEmpty(CardStore.cardDatas)}
       />
     </>
   );

--- a/src/containers/MapContainer.js
+++ b/src/containers/MapContainer.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-nested-ternary */
 /* global kakao */
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useHistory } from "react-router-dom";
@@ -9,6 +10,7 @@ import Map from "../components/Map/Map";
 import { ReactComponent as LocationIcon } from "../images/icon-locate.svg";
 import { ReactComponent as LocationActiveIcon } from "../images/icon-locate-active.svg";
 import FloatingActionButton from "../components/FloatingActionButton/FloatingActionButton";
+import BlinkingLocationIcon from "../components/BlinkingLocationIcon/BlinkingLocationIcon";
 import Card from "../components/Card/Card";
 import useGeoLocation from "../hooks/useGeoLocation";
 import MapPickerSprite from "../images/icon-mappicker-sprite.png";
@@ -201,7 +203,9 @@ const MapContainer = () => {
   return (
     <>
       <Map mapRef={mapRef} isSelected={!!nowSelectingCafe}>
-        <FloatingActionButton onClick={handleLocationButtonClick}>{!currentCoordinates || isFetching || !isOutOfCenter ? <LocationIcon /> : <LocationActiveIcon />}</FloatingActionButton>
+        <FloatingActionButton onClick={handleLocationButtonClick}>
+          {!currentCoordinates || isFetching || !isOutOfCenter ? <LocationIcon /> : CardStore.isLoading.fetchCard ? <BlinkingLocationIcon /> : <LocationActiveIcon />}
+        </FloatingActionButton>
       </Map>
       {nowSelectingCafe && <Card showOnlyInfo={true} onCardLinkClick={() => handleCardLinkClick(nowSelectingCafe)} cardData={nowSelectingCafe} />}
     </>

--- a/src/utils/GeoLocationUtils.js
+++ b/src/utils/GeoLocationUtils.js
@@ -24,11 +24,7 @@ class GeoLocationUtils {
       if ("geolocation" in navigator) {
         navigator.geolocation.getCurrentPosition(
           position => {
-            // const { coords } = position;
-            const coords = {
-              latitude: 37.490095,
-              longitude: 127.02761,
-            };
+            const { coords } = position;
             resolve(coords);
           },
           err => {

--- a/src/utils/GeoLocationUtils.js
+++ b/src/utils/GeoLocationUtils.js
@@ -24,7 +24,11 @@ class GeoLocationUtils {
       if ("geolocation" in navigator) {
         navigator.geolocation.getCurrentPosition(
           position => {
-            const { coords } = position;
+            // const { coords } = position;
+            const coords = {
+              latitude: 37.490095,
+              longitude: 127.02761,
+            };
             resolve(coords);
           },
           err => {


### PR DESCRIPTION
![작업공간5](https://user-images.githubusercontent.com/2542730/91451431-5ec7cb80-e8b8-11ea-9cb6-2793bbb6d1c0.gif)
지도 페이지에서는 마커를 불러오는 중임을 알 수 있는 방법이 없어서
`CardStore.cardDatas`가 불러오는 중일 때 현위치 아이콘이 반짝이도록 구현해봤습니다.
CardList에서도 통일성을 위해 Header의 위치 아이콘이 반짝이도록 동일하게 적용해두었습니다.