### PR TITLE
상세 페이지에서 거리와 평가 참여 수 데이터 없을 시 표시 변경

### DIFF
--- a/src/components/DetailInfo/DetailTitle.js
+++ b/src/components/DetailInfo/DetailTitle.js
@@ -31,7 +31,7 @@ const DetailTitle = props => {
 
 DetailTitle.defaultProps = {
   id: "Cafe",
-  distance: "0km",
+  distance: "-",
   rating: 0.0,
   tagCount: 10,
 };

--- a/src/components/RatingStar/RatingStar.js
+++ b/src/components/RatingStar/RatingStar.js
@@ -24,7 +24,7 @@ const RatingStar = props => {
           <span className="rating_count_current">{rating}점</span>
           <span className="rating_count_total">{isShowRatingTotal && ` / ${starCount}점`}</span>
         </span>
-        {isShowAttendantCount && <span className="rating_attendant_count">({attendantCount}명 참여)</span>}
+        {isShowAttendantCount && attendantCount > 0 && <span className="rating_attendant_count">({attendantCount}명 참여)</span>}
       </p>
     );
   }, [isShowAttendantCount, isShowRatingTotal, starCount, attendantCount, rating]);


### PR DESCRIPTION
![캡처](https://user-images.githubusercontent.com/2542730/91533932-a9deee80-e94b-11ea-902c-d6394be9dfb5.PNG)
distance와 평가 참여 인원수가 보이지 않을 경우를 대비하여
표시가 비교적 어색하지 않게 보이도록 변경하였습니다.