### PR TITLE
[Detail] 뒤로 가기 버튼을 눌렀을 때 뒤로 갈 페이지가 없다면 메인으로 이동

### DIFF
--- a/src/containers/HeaderContainer.js
+++ b/src/containers/HeaderContainer.js
@@ -19,7 +19,11 @@ const HeaderContainer = props => {
   }, [fetch, CardStore]);
 
   const handleBackButtonClick = useCallback(() => {
-    history.goBack();
+    if (document.referrer && document.referrer.indexOf(window.location.host) >= 0) {
+      history.goBack();
+    } else {
+      window.location.href = `${window.location.protocol}//${window.location.host}`;
+    }
   }, [history]);
 
   const handleMapLinkButtonClick = useCallback(() => {


### PR DESCRIPTION
상세 페이지로 가는 링크로 바로 페이지를 접속했을 경우
뒤로 가기 버튼이 작동하지 않는 문제가 있어
올바르게 메인으로 이동하도록 수정했습니다.