### PR TITLE
Fix/flashing

### DIFF
--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -1,4 +1,5 @@
 import React, { useCallback } from "react";
+import { isEmpty } from "lodash";
 import CardStyled from "./Card.styles";
 import CardView from "./CardView";
 import CardInfo from "./CardInfo";

--- a/src/components/CardList/CardList.js
+++ b/src/components/CardList/CardList.js
@@ -7,10 +7,20 @@ import LoadingBar from "../LoadingBar/LoadingBar";
 
 const CardList = props => {
   const { standard, cardDatas, onCardLinkClick, cardHeight, loadNextPage, LoadingIndicator, hasNextPage, isNextPageLoading, hasMainShow } = props;
-  /* prettier-ignore */
-  const Item = useCallback(({ data }) => {
-    return <Card cardData={data} onCardLinkClick={onCardLinkClick} hasMainShow={hasMainShow} />;
-	}, [onCardLinkClick, hasMainShow]);
+
+  const CardItem = useCallback(
+    ({ style, index, data }) => {
+      /* prettier-ignore */
+      if (!data[index]) (<div style={style}><LoadingIndicator /></div>);
+
+      return (
+        <div style={style}>
+          <Card cardData={data[index]} onCardLinkClick={onCardLinkClick} hasMainShow={hasMainShow} />
+        </div>
+      );
+    },
+    [onCardLinkClick, hasMainShow, LoadingIndicator],
+  );
 
   return (
     <CardListStyled>
@@ -25,7 +35,7 @@ const CardList = props => {
       </div>
       <InfiniteScroller
         datas={cardDatas}
-        Item={Item}
+        Item={CardItem}
         itemSize={cardHeight}
         hasNextPage={hasNextPage}
         isNextPageLoading={isNextPageLoading}

--- a/src/components/CardList/CardList.js
+++ b/src/components/CardList/CardList.js
@@ -11,7 +11,7 @@ const CardList = props => {
   const CardItem = useCallback(
     ({ style, index, data }) => {
       /* prettier-ignore */
-      if (!data[index]) (<div style={style}><LoadingIndicator /></div>);
+      if (!data[index]) return <div style={style}><LoadingIndicator /></div>;
 
       return (
         <div style={style}>

--- a/src/components/InfiniteScroller/InfiniteScroller.js
+++ b/src/components/InfiniteScroller/InfiniteScroller.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, memo } from "react";
+import React, { useCallback, useRef } from "react";
 import { FixedSizeList } from "react-window";
 import InfiniteLoader from "react-window-infinite-loader";
 import AutoSizer from "react-virtualized-auto-sizer";
@@ -6,32 +6,15 @@ import { WindowScroller } from "react-virtualized";
 import LoadingBar from "../LoadingBar/LoadingBar";
 
 const InfiniteScroller = props => {
-  const { itemSize, datas, hasNextPage, isNextPageLoading, loadNextPage, LoadingIndicator, Item, threshold, overscanCount } = props;
+  const { itemSize, datas, hasNextPage, isNextPageLoading, loadNextPage, Item, threshold, overscanCount } = props;
   const isItemLoaded = useCallback(index => !hasNextPage || index < datas.length, [hasNextPage, datas]);
   const loadMoreItems = useCallback(isNextPageLoading ? () => {} : loadNextPage, [isNextPageLoading, loadNextPage]);
   const fixedSizeListRef = useRef();
-  const MemoizedItem = memo(({ data }) => <Item data={data} />);
   const itemCount = hasNextPage ? datas.length + threshold : datas.length;
 
   const handleWindowScroll = useCallback(({ scrollTop }) => {
     fixedSizeListRef.current.scrollTo(scrollTop);
   }, []);
-
-  const Row = ({ index, style }) => {
-    if (!isItemLoaded(index)) {
-      return (
-        <div style={style}>
-          <LoadingIndicator />
-        </div>
-      );
-    }
-
-    return (
-      <div style={style}>
-        <MemoizedItem data={datas[index]} />
-      </div>
-    );
-  };
 
   return (
     <>
@@ -50,12 +33,13 @@ const InfiniteScroller = props => {
                   height={window.innerHeight}
                   itemCount={itemCount}
                   itemSize={itemSize}
+                  itemData={datas}
                   onItemsRendered={onItemsRendered}
                   overscanCount={overscanCount}
                   style={{ height: "100% !important" }}
                   {...props}
                 >
-                  {Row}
+                  {Item}
                 </FixedSizeList>
               )}
             </AutoSizer>
@@ -74,8 +58,7 @@ InfiniteScroller.defaultProps = {
   threshold: 10, // 아래 몇개의 Row가 남았을때 fetch 할건지
   overscanCount: 10, // 아래 몇개의 Row가 미리 렌더링 될지
   loadNextPage: () => console.log("loadNextPage"),
-  LoadingIndicator: () => <LoadingBar />,
-  Item: ({ data }) => <div>{data}</div>,
+  Item: ({ style, data }) => <div style={style}>{data}</div>,
 };
 
 export default InfiniteScroller;


### PR DESCRIPTION
깜빡임의 원인은 인피니티스크롤에 전달된 Row 컴포넌트의 참조값이 계속 변경됬기 때문입니다.

### infiniteScroller.js
```js
<FixedSizeList ...props들>{Item}</FixedSizeList>
```
여기서 Item이 기존에는 인라인 함수로 정의되어있어서 매번 새로운 함수가 할당되고 있었습니다.

데이터를 서버에서 새로 받아와서 컨테이너를통해 다시 UI컴포넌트에 주입하게 되면 저 Item컴포넌트가 새로 만들어지고
결국엔 이전 Item컴포넌트와 새로운 데이터로 다시 렌더링된 Item컴포넌트가 참조값이 다른 서로 다른 함수가 되어 버립니다.

리액트는 이전 렌더링과 다음 렌더링에서 같은 컴포넌트의 엘리먼트 타입이 다를 경우 업데이트를하는게 아니라 unmount후 -> 다시 mount하는 과정을 거칩니다.

그래서 데이터를 새로 받아올떄마다 list내에 있는 row들이 계속 unmount->mount를 반복했던거고 그 과정에서 이미지가 디코딩되기 전의 상태가 그대로 화면에 노출되어 깜빡거리는듯한 현상처럼 보인겁니다.

문제는 컴포넌트가 unmount되는것을 방지하고 리렌더링되게끔 하는건데 결국엔 row에 useCallback을 적용하여 새로운 함수가 할당되는것을 방지하는것으로 해결했습니다.

![image](https://user-images.githubusercontent.com/29771088/92683837-ec9ebe80-f36e-11ea-93df-432983750167.png)

### 참고자료
https://react-window.now.sh/#/examples/list/memoized-list-items
https://medium.com/@migcoder/difference-between-render-and-component-prop-on-react-router-v4-368ca7fedbec
https://codesandbox.io/s/qx4088mn36?file=/index.js:577-588
