### PR TITLE
fix: 지도 마커 이미지를 svg로 변경

### DIFF
--- a/src/containers/MapContainer.js
+++ b/src/containers/MapContainer.js
@@ -15,17 +15,19 @@ import FloatingActionButton from "../components/FloatingActionButton/FloatingAct
 import BlinkingLocationIcon from "../components/BlinkingLocationIcon/BlinkingLocationIcon";
 import Card from "../components/Card/Card";
 import useGeoLocation from "../hooks/useGeoLocation";
-import MapPickerSprite from "../images/icon-mappicker-sprite.png";
+import MapPickerSprite from "../images/icon-mappicker-sprite.svg";
 
 const selectedMarkerImage = new kakao.maps.MarkerImage(MapPickerSprite, new kakao.maps.Size(48, 48), {
   spriteOrigin: new kakao.maps.Point(24, 0),
   spriteSize: new kakao.maps.Size(72, 48),
   offset: new kakao.maps.Point(23, 46),
 });
+
 const unselectedMarkerImage = new kakao.maps.MarkerImage(MapPickerSprite, new kakao.maps.Size(24, 24), {
   spriteOrigin: new kakao.maps.Point(0, 0),
   spriteSize: new kakao.maps.Size(72, 48),
 });
+
 const currentLocationMarkerImage = new kakao.maps.MarkerImage(CurrentLocationIcon, new kakao.maps.Size(36, 36), {
   offset: new kakao.maps.Point(18, 18),
 });

--- a/src/images/icon-mappicker-sprite.svg
+++ b/src/images/icon-mappicker-sprite.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg235"
+   width="76.800003"
+   height="51.200001"
+   viewBox="0 0 76.800003 51.200001"
+   sodipodi:docname="icon-mappicker-sprite.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <metadata
+     id="metadata241">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs239" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     id="namedview237"
+     showgrid="false"
+     inkscape:zoom="13.841145"
+     inkscape:cx="38.400002"
+     inkscape:cy="25.6"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g243" />
+  <g
+     inkscape:groupmode="layer"
+     inkscape:label="Image"
+     id="g243">
+    <g
+       fill="none"
+       fill-rule="evenodd"
+       id="g52"
+       transform="translate(27.224085,1.2926633)"
+       inkscape:transform-center-x="-32.902926"
+       inkscape:transform-center-y="4.1527965">
+      <g
+         fill-rule="nonzero"
+         id="g50">
+        <g
+           id="g48">
+          <path
+             fill="#ffbb44"
+             stroke="#eba01f"
+             d="m 24,4.5 c 4.002,0 7.636,1.516 10.266,3.975 2.612,2.442 4.234,5.814 4.234,9.547 0,6.715 -5.39,16.14 -12.453,25.461 C 25.571,44.123 24.809,44.5 24,44.5 23.192,44.5 22.43,44.125 21.958,43.49 14.89,34.158 9.5,24.732 9.5,18.022 9.5,14.289 11.122,10.917 13.734,8.475 16.364,6.016 19.998,4.5 24,4.5 Z"
+             id="path44" />
+          <path
+             fill="#ffffff"
+             d="m 24,14 c 2.761,0 5,2.239 5,5 0,2.761 -2.239,5 -5,5 -2.761,0 -5,-2.239 -5,-5 0,-2.761 2.239,-5 5,-5 z"
+             id="path46" />
+        </g>
+      </g>
+    </g>
+    <g
+       fill="none"
+       fill-rule="evenodd"
+       id="g84"
+       transform="translate(0.86020771,0.57121401)">
+      <g
+         fill="#ffbb44"
+         fill-rule="nonzero"
+         stroke="#eba01f"
+         id="g82">
+        <g
+           id="g80">
+          <path
+             d="m 12,1.5 c 2.072,0 3.953,0.789 5.315,2.07 1.347,1.267 2.185,3.016 2.185,4.954 0,3.57 -2.867,8.573 -6.596,13.525 C 12.694,22.333 12.357,22.5 12,22.5 11.644,22.5 11.307,22.334 11.098,22.051 7.367,17.095 4.5,12.091 4.5,8.524 4.5,6.586 5.338,4.837 6.685,3.57 8.047,2.289 9.928,1.5 12,1.5 Z"
+             id="path78" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
지도 마커 이미지를 png에서 svg로 수정해서 올렸습니다
svg 이미지를 하나의 svg 이미지로 합쳐서 만들었는데 디자이너분들의 컨펌이 필요해 보입니다