### PR TITLE
ios 폰트 크기 오류 수정

### DIFF
--- a/src/components/DetailInfo/DetailInfo.styles.js
+++ b/src/components/DetailInfo/DetailInfo.styles.js
@@ -31,8 +31,6 @@ const DetailInfoStyled = styled.div`
     font-size: inherit;
   }
   .info-item-text {
-    width: calc(100% - 77px);
-    height: 100%;
     display: inline-flex;
     font-size: inherit;
   }

--- a/src/components/DetailInfo/DetailInfo.styles.js
+++ b/src/components/DetailInfo/DetailInfo.styles.js
@@ -31,7 +31,10 @@ const DetailInfoStyled = styled.div`
     font-size: inherit;
   }
   .info-item-text {
-    font-size: 12px;
+    width: calc(100% - 77px);
+    height: 100%;
+    display: inline-flex;
+    font-size: ingerit;
   }
   .info-item-box {
     display: inline-flex;

--- a/src/components/DetailInfo/DetailInfo.styles.js
+++ b/src/components/DetailInfo/DetailInfo.styles.js
@@ -34,7 +34,7 @@ const DetailInfoStyled = styled.div`
     width: calc(100% - 77px);
     height: 100%;
     display: inline-flex;
-    font-size: ingerit;
+    font-size: inherit;
   }
   .info-item-box {
     display: inline-flex;


### PR DESCRIPTION
css 에서 발생하는 오류라 짐작됩니다. 폰트가 커지지 않는 부분은 div 로 감싸져 있고, 오류가 발생하는 부분은 span 으로 되어있는 걸로 보아 block 과 inline 의 차이가 있는 듯 합니다.